### PR TITLE
Adds measure & transmission of back-pressure from Job queue to Receivers

### DIFF
--- a/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/StreamingContext.scala
@@ -41,7 +41,7 @@ import org.apache.spark.storage.StorageLevel
 import org.apache.spark.streaming.StreamingContextState._
 import org.apache.spark.streaming.dstream._
 import org.apache.spark.streaming.receiver.{ActorReceiver, ActorSupervisorStrategy, Receiver}
-import org.apache.spark.streaming.scheduler.{JobScheduler, StreamingListener}
+import org.apache.spark.streaming.scheduler.{JobScheduler, StreamingListener, LatestSpeedListener}
 import org.apache.spark.streaming.ui.{StreamingJobProgressListener, StreamingTab}
 import org.apache.spark.util.{CallSite, Utils}
 
@@ -184,6 +184,8 @@ class StreamingContext private[streaming] (
   private[streaming] val waiter = new ContextWaiter
 
   private[streaming] val progressListener = new StreamingJobProgressListener(this)
+
+  private[streaming] val speedListener = new LatestSpeedListener(this.graph.batchDuration)
 
   private[streaming] val uiTab: Option[StreamingTab] =
     if (conf.getBoolean("spark.ui.enabled", true)) {

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/CongestionStrategy.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/CongestionStrategy.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.streaming.receiver
+
+import scala.collection.mutable.ArrayBuffer
+
+/**
+ * This trait provides a strategy to deal with a large amount of data seen
+ * at a Receiver, possibly ensuing an exhaustion of resources.
+ * See SPARK-7398
+ * Any long blocking operation in this class will hurt the throughput.
+ */
+trait CongestionStrategy {
+
+  /**
+  * Called on every batch interval with the estimated maximum number of
+  * elements per block that can been processed in a batch interval,
+  * based on the processing speed observed over the last batch.
+  */
+  def onBlockBoundUpdate(bound: Int): Unit
+
+  /**
+  * Given data buffers intended for a block, and for the following block
+  * mutates those buffers to an amount appropriate with respect to the
+  * back-pressure information provided through `onBlockBoundUpdate`.
+  */
+  def restrictCurrentBuffer(currentBuffer: ArrayBuffer[Any], nextBuffer: ArrayBuffer[Any]): Unit
+
+}

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/CongestionStrategyImpl.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/CongestionStrategyImpl.scala
@@ -17,12 +17,17 @@
 
 package org.apache.spark.streaming.receiver
 
-import org.apache.spark.streaming.Time
+import scala.collection.mutable.ArrayBuffer
 
-/** Messages sent to the Receiver. */
-private[streaming] sealed trait ReceiverMessage extends Serializable
-private[streaming] object StopReceiver extends ReceiverMessage
-private[streaming] case class CleanupOldBlocks(threshTime: Time) extends ReceiverMessage
-private[streaming] case class BatchProcessingSpeedInfo(batchTime: Time, elementsPerBlock: Int)
-  extends ReceiverMessage
+/**
+ * This class provides a congestion strategy that ignores
+ * any back-pressure information.
+ * @see CongestionStrategy
+ */
+class IgnoreCongestionStrategy extends CongestionStrategy {
 
+  override def onBlockBoundUpdate(bound: Int) {}
+
+  override def restrictCurrentBuffer(currentBuffer: ArrayBuffer[Any],
+                                     nextBuffer: ArrayBuffer[Any]): Unit = {}
+}

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverMessage.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverMessage.scala
@@ -23,4 +23,6 @@ import org.apache.spark.streaming.Time
 private[streaming] sealed trait ReceiverMessage extends Serializable
 private[streaming] object StopReceiver extends ReceiverMessage
 private[streaming] case class CleanupOldBlocks(threshTime: Time) extends ReceiverMessage
+private[streaming] case class BatchProcessingSpeedInfo(batchTime: Time, elementsPerBatch: Long)
+		   extends ReceiverMessage
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisorImpl.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisorImpl.scala
@@ -77,6 +77,8 @@ private[streaming] class ReceiverSupervisorImpl(
         case CleanupOldBlocks(threshTime) =>
           logDebug("Received delete old batch signal")
           cleanupOldBlocks(threshTime)
+        case BatchProcessingSpeedInfo(batchTime, elemsPerBatch) =>
+          logDebug(s"Received update for $streamId at ${batchTime.milliseconds} : $elemsPerBatch")
       }
     })
 

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -67,6 +67,7 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
     eventLoop.start()
 
     listenerBus.start(ssc.sparkContext)
+    ssc.addStreamingListener(ssc.speedListener)
     receiverTracker = new ReceiverTracker(ssc)
     inputInfoTracker = new InputInfoTracker(ssc)
     receiverTracker.start()

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/JobScheduler.scala
@@ -170,6 +170,9 @@ class JobScheduler(val ssc: StreamingContext) extends Logging {
             jobSet.processingDelay / 1000.0
           ))
           listenerBus.post(StreamingListenerBatchCompleted(jobSet.toBatchInfo))
+          for { time <- ssc.speedListener.latestTime
+                speeds <- ssc.speedListener.streamIdToElemsPerBatch}
+            receiverTracker.refreshLatestSpeeds(time, speeds)
         }
       case Failure(e) =>
         reportError("Error running job " + job, e)

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
@@ -25,6 +25,7 @@ import org.apache.spark.{Logging, SerializableWritable, SparkEnv, SparkException
 import org.apache.spark.rpc._
 import org.apache.spark.streaming.{StreamingContext, Time}
 import org.apache.spark.streaming.receiver.{CleanupOldBlocks, Receiver, ReceiverSupervisorImpl, StopReceiver}
+import org.apache.spark.streaming.receiver.BatchProcessingSpeedInfo
 
 /**
  * Messages used by the NetworkReceiver and the ReceiverTracker to communicate
@@ -132,6 +133,17 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
       receiverInfo.values.flatMap { info => Option(info.endpoint) }
         .foreach { _.send(CleanupOldBlocks(cleanupThreshTime)) }
     }
+  }
+
+  /**
+   * Updates a receiver on the processing speed of its stream, counted in elements
+   * processed per batch interval.
+   */
+  def refreshLatestSpeeds(batchTime: Time, streamIdToElemsPerBatch: Map[Int, Long]){
+    for {(sId, speed) <- streamIdToElemsPerBatch
+        info <- receiverInfo.get(sId)
+        eP <- Option(info.endpoint)}
+    eP.send(BatchProcessingSpeedInfo(batchTime, speed))
   }
 
   /** Register a receiver */

--- a/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
+++ b/streaming/src/main/scala/org/apache/spark/streaming/scheduler/ReceiverTracker.scala
@@ -140,10 +140,12 @@ class ReceiverTracker(ssc: StreamingContext, skipReceiverLaunch: Boolean = false
    * processed per batch interval.
    */
   def refreshLatestSpeeds(batchTime: Time, streamIdToElemsPerBatch: Map[Int, Long]){
+    val blockIntervalMs = ssc.conf.getTimeAsMs("spark.streaming.blockInterval", "200ms")
+    val ratio = blockIntervalMs.toFloat / ssc.graph.batchDuration.milliseconds
     for {(sId, speed) <- streamIdToElemsPerBatch
         info <- receiverInfo.get(sId)
         eP <- Option(info.endpoint)}
-    eP.send(BatchProcessingSpeedInfo(batchTime, speed))
+    if (speed > 0) eP.send(BatchProcessingSpeedInfo(batchTime, math.round( speed * ratio )))
   }
 
   /** Register a receiver */


### PR DESCRIPTION
The logging statement is in the [next to last](https://github.com/huitseeker/spark/commit/7e9a0b3480f3b9aadc5235d9e9b4c5e2640009d4) commit, suitable for test-bed purposes (but not yet for merging).
