### PR TITLE
Extract the rate limiter, and enable using the reciever as rate limiter

### DIFF
--- a/streaming/src/test/scala/org/apache/spark/streaming/ReceiverSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/ReceiverSuite.scala
@@ -20,20 +20,18 @@ package org.apache.spark.streaming
 import java.io.File
 import java.nio.ByteBuffer
 import java.util.concurrent.Semaphore
-
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-
 import org.scalatest.concurrent.Eventually._
 import org.scalatest.concurrent.Timeouts
 import org.scalatest.time.SpanSugar._
-
 import org.apache.spark.SparkConf
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.storage.StreamBlockId
 import org.apache.spark.streaming.receiver._
 import org.apache.spark.streaming.receiver.WriteAheadLogBasedBlockHandler._
 import org.apache.spark.util.Utils
+import org.apache.spark.streaming.receiver.SupervisorRateLimiter
 
 /** Testsuite for testing the network receiver behavior */
 class ReceiverSuite extends TestSuiteBase with Timeouts with Serializable {
@@ -135,7 +133,7 @@ class ReceiverSuite extends TestSuiteBase with Timeouts with Serializable {
     val maxRate = 1001
     val conf = new SparkConf().set("spark.streaming.blockInterval", s"${blockIntervalMs}ms").
       set("spark.streaming.receiver.maxRate", maxRate.toString)
-    val blockGenerator = new BlockGenerator(blockGeneratorListener, 1, conf)
+    val blockGenerator = new BlockGenerator(blockGeneratorListener, 1, conf, new SupervisorRateLimiter(conf))
     val expectedBlocks = 20
     val waitTime = expectedBlocks * blockIntervalMs
     val expectedMessages = maxRate * waitTime / 1000

--- a/streaming/src/test/scala/org/apache/spark/streaming/receiver/BlockGeneratorSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/receiver/BlockGeneratorSuite.scala
@@ -55,7 +55,7 @@ class BlockGeneratorSuite extends SparkFunSuite with BeforeAndAfter {
     require(listener.onPushBlockCalled === false)
 
     // Verify that creating the generator does not start it
-    blockGenerator = new BlockGenerator(listener, 0, conf, clock)
+    blockGenerator = new BlockGenerator(listener, 0, conf, new SupervisorRateLimiter(conf), clock)
     assert(blockGenerator.isActive() === false, "block generator active before start()")
     assert(blockGenerator.isStopped() === false, "block generator stopped before start()")
     assert(listener.onAddDataCalled === false)
@@ -143,7 +143,7 @@ class BlockGeneratorSuite extends SparkFunSuite with BeforeAndAfter {
   test("stop ensures correct shutdown") {
     val listener = new TestBlockGeneratorListener
     val clock = new ManualClock()
-    blockGenerator = new BlockGenerator(listener, 0, conf, clock)
+    blockGenerator = new BlockGenerator(listener, 0, conf, new SupervisorRateLimiter(conf), clock)
     require(listener.onGenerateBlockCalled === false)
     blockGenerator.start()
     assert(blockGenerator.isActive() === true, "block generator")
@@ -211,7 +211,7 @@ class BlockGeneratorSuite extends SparkFunSuite with BeforeAndAfter {
         errorReported = true
       }
     }
-    blockGenerator = new BlockGenerator(listener, 0, conf)
+    blockGenerator = new BlockGenerator(listener, 0, conf,  new SupervisorRateLimiter(conf))
     blockGenerator.start()
     assert(listener.errorReported === false)
     blockGenerator.addData(1)

--- a/streaming/src/test/scala/org/apache/spark/streaming/receiver/RateLimiterSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/receiver/RateLimiterSuite.scala
@@ -25,21 +25,21 @@ class RateLimiterSuite extends SparkFunSuite {
 
   test("rate limiter initializes even without a maxRate set") {
     val conf = new SparkConf()
-    val rateLimiter = new RateLimiter(conf) {}
+    val rateLimiter = new SupervisorRateLimiter(conf) {}
     rateLimiter.updateRate(105)
     assert(rateLimiter.getCurrentLimit == 105)
   }
 
   test("rate limiter updates when below maxRate") {
     val conf = new SparkConf().set("spark.streaming.receiver.maxRate", "110")
-    val rateLimiter = new RateLimiter(conf) {}
+    val rateLimiter = new SupervisorRateLimiter(conf) {}
     rateLimiter.updateRate(105)
     assert(rateLimiter.getCurrentLimit == 105)
   }
 
   test("rate limiter stays below maxRate despite large updates") {
     val conf = new SparkConf().set("spark.streaming.receiver.maxRate", "100")
-    val rateLimiter = new RateLimiter(conf) {}
+    val rateLimiter = new SupervisorRateLimiter(conf) {}
     rateLimiter.updateRate(105)
     assert(rateLimiter.getCurrentLimit === 100)
   }

--- a/streaming/src/test/scala/org/apache/spark/streaming/scheduler/ReceiverTrackerSuite.scala
+++ b/streaming/src/test/scala/org/apache/spark/streaming/scheduler/ReceiverTrackerSuite.scala
@@ -153,7 +153,7 @@ private[streaming] class RateTestReceiver(receiverId: Int, host: Option[String] 
   }
 
   def getCustomBlockGeneratorRateLimit(): Long = {
-    customBlockGenerator.getCurrentLimit
+    customBlockGenerator.rateLimiter.getCurrentLimit
   }
 }
 


### PR DESCRIPTION
Other solution to forward the rate limit to the receiver (instead of the block generator).
In addition to the solution from the design, it also remove the Guava blocking limiter from the code path if the receiver is used for rate limiter

Extracted a class hierarchy for rate limiter.
If the receiver is also a rate limiter, the rate limit is sent to it. Otherwise the rate limit is sent to the rate limiter contained in the block generator.

I still need to work a bit on the new classes/methods names. If you have good/better ideas, just add them in a comment.
