### PR TITLE
Add lightbend custom suite

### DIFF
--- a/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
+++ b/resource-managers/kubernetes/docker/src/main/dockerfiles/spark/entrypoint.sh
@@ -27,6 +27,14 @@ set +e
 uidentry=$(getent passwd $myuid)
 set -e
 
+if [ -n "$HADOOP_CONFIG_URL" ]; then
+   echo "Setting up hadoop config files...."
+   mkdir -p /etc/hadoop/conf
+   wget $HADOOP_CONFIG_URL/core-site.xml -P /etc/hadoop/conf
+   wget $HADOOP_CONFIG_URL/hdfs-site.xml -P /etc/hadoop/conf
+   export HADOOP_CONF_DIR=/etc/hadoop/conf
+fi
+
 # If there is no passwd entry for the container UID, attempt to create one
 if [ -z "$uidentry" ] ; then
     if [ -w /etc/passwd ] ; then

--- a/resource-managers/kubernetes/integration-tests/dev/dev-run-integration-tests.sh
+++ b/resource-managers/kubernetes/integration-tests/dev/dev-run-integration-tests.sh
@@ -27,6 +27,9 @@ IMAGE_TAG="N/A"
 SPARK_MASTER=
 NAMESPACE=
 SERVICE_ACCOUNT=
+EXTRA_JARS=
+INCLUDE_TAGS=
+EXCLUDE_TAGS=
 
 # Parse arguments
 while (( "$#" )); do
@@ -59,6 +62,18 @@ while (( "$#" )); do
       SERVICE_ACCOUNT="$2"
       shift
       ;;
+    --extra-jars)
+      EXTRA_JARS="$2"
+      shift
+      ;;
+    --include-tags)
+      INCLUDE_TAGS="$2"
+      shift
+      ;;
+    --exclude-tags)
+      EXCLUDE_TAGS="$2"
+      shift
+      ;;
     *)
       break
       ;;
@@ -88,6 +103,21 @@ fi
 if [ -n $SPARK_MASTER ];
 then
   properties=( ${properties[@]} -Dspark.kubernetes.test.master=$SPARK_MASTER )
+fi
+
+if [ -n $EXTRA_JARS ];
+then
+  properties=( ${properties[@]} -Dspark.kubernetes.test.extraJars=$EXTRA_JARS )
+fi
+
+if [ -n $EXCLUDE_TAGS ];
+then
+  properties=( ${properties[@]} -Dtest.exclude.tags=$EXCLUDE_TAGS )
+fi
+
+if [ -n $INCLUDE_TAGS ];
+then
+  properties=( ${properties[@]} -Dtest.include.tags=$INCLUDE_TAGS )
 fi
 
 ../../../build/mvn integration-test ${properties[@]}

--- a/resource-managers/kubernetes/integration-tests/pom.xml
+++ b/resource-managers/kubernetes/integration-tests/pom.xml
@@ -40,6 +40,7 @@
     <spark.kubernetes.test.deployMode>minikube</spark.kubernetes.test.deployMode>
     <spark.kubernetes.test.imageRepo>docker.io/kubespark</spark.kubernetes.test.imageRepo>
     <test.exclude.tags></test.exclude.tags>
+    <test.include.tags></test.include.tags>
   </properties>
   <packaging>jar</packaging>
   <name>Spark Project Kubernetes Integration Tests</name>
@@ -102,7 +103,18 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.7</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+      <plugin>
+
+
         <!-- Triggers scalatest plugin in the integration-test phase instead of
              the test phase. -->
         <groupId>org.scalatest</groupId>
@@ -112,11 +124,12 @@
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
           <junitxml>.</junitxml>
           <filereports>SparkTestSuite.txt</filereports>
-          <argLine>-ea -Xmx3g -XX:ReservedCodeCacheSize=512m ${extraScalaTestArgs}</argLine>
+          <argLine>-ea -Xmx3g -XX:ReservedCodeCacheSize=512m ${extraScalaTestArgs} </argLine>
           <stderr/>
           <systemProperties>
             <log4j.configuration>file:src/test/resources/log4j.properties</log4j.configuration>
             <java.awt.headless>true</java.awt.headless>
+            <spark.kubernetes.test.extraJars>${spark.kubernetes.test.extraJars}</spark.kubernetes.test.extraJars>
             <spark.kubernetes.test.imageTagFile>${spark.kubernetes.test.imageTagFile}</spark.kubernetes.test.imageTagFile>
             <spark.kubernetes.test.unpackSparkDir>${spark.kubernetes.test.unpackSparkDir}</spark.kubernetes.test.unpackSparkDir>
             <spark.kubernetes.test.imageRepo>${spark.kubernetes.test.imageRepo}</spark.kubernetes.test.imageRepo>
@@ -126,6 +139,7 @@
             <spark.kubernetes.test.serviceAccountName>${spark.kubernetes.test.serviceAccountName}</spark.kubernetes.test.serviceAccountName>
           </systemProperties>
           <tagsToExclude>${test.exclude.tags}</tagsToExclude>
+          <tagsToInclude>${test.include.tags}</tagsToInclude>
         </configuration>
         <executions>
           <execution>

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesTestComponents.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/KubernetesTestComponents.scala
@@ -105,16 +105,13 @@ private[spark] object SparkAppLauncher extends Logging {
       sparkHomeDir: Path): Unit = {
     val sparkSubmitExecutable = sparkHomeDir.resolve(Paths.get("bin", "spark-submit"))
     logInfo(s"Launching a spark app with arguments $appArguments and conf $appConf")
-    val appArgsArray =
-      if (appArguments.appArgs.length > 0) Array(appArguments.appArgs.mkString(" "))
-      else Array[String]()
     val commandLine = (Array(sparkSubmitExecutable.toFile.getAbsolutePath,
       "--deploy-mode", "cluster",
       "--class", appArguments.mainClass,
       "--master", appConf.get("spark.master")
     ) ++ appConf.toStringArray :+
       appArguments.mainAppResource) ++
-      appArgsArray
+      appArguments.appArgs
     ProcessUtils.executeProcess(commandLine, timeoutSecs)
   }
 }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/IntegrationTestBackend.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/IntegrationTestBackend.scala
@@ -19,6 +19,7 @@ package org.apache.spark.deploy.k8s.integrationtest.backend
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient
 
+import org.apache.spark.deploy.k8s.integrationtest.backend.cloud.CloudTestBackend
 import org.apache.spark.deploy.k8s.integrationtest.backend.minikube.MinikubeTestBackend
 
 private[spark] trait IntegrationTestBackend {
@@ -35,7 +36,10 @@ private[spark] object IntegrationTestBackendFactory {
       .getOrElse("minikube")
     if (deployMode == "minikube") {
       MinikubeTestBackend
-    } else {
+    } else if (deployMode == "cloud") {
+      CloudTestBackend
+    }
+    else {
       throw new IllegalArgumentException(
         "Invalid " + deployModeConfigKey + ": " + deployMode)
     }

--- a/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/cloud/CloudTestBackend.scala
+++ b/resource-managers/kubernetes/integration-tests/src/test/scala/org/apache/spark/deploy/k8s/integrationtest/backend/cloud/CloudTestBackend.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.k8s.integrationtest.backend.cloud
+
+import io.fabric8.kubernetes.client.{ConfigBuilder, DefaultKubernetesClient}
+
+import org.apache.spark.deploy.k8s.integrationtest.backend.IntegrationTestBackend
+import org.apache.spark.util.Utils
+
+private[spark] object CloudTestBackend extends IntegrationTestBackend {
+
+  private var defaultClient: DefaultKubernetesClient = _
+
+  override def initialize(): Unit = {
+    val masterUrl = Option(System.getProperty("spark.kubernetes.test.master"))
+      .getOrElse(throw new RuntimeException("Kubernetes master URL is not set"))
+    val k8sConf = new ConfigBuilder()
+      .withApiVersion("v1")
+      .withMasterUrl(Utils.checkAndGetK8sMasterUrl(masterUrl).replaceFirst("k8s://", ""))
+      .build()
+    defaultClient = new DefaultKubernetesClient(k8sConf)
+  }
+
+  override def getKubernetesClient: DefaultKubernetesClient = {
+    defaultClient
+  }
+}

--- a/resource-managers/kubernetes/lightbend-build/README.md
+++ b/resource-managers/kubernetes/lightbend-build/README.md
@@ -1,0 +1,38 @@
+# Instructions
+
+This project adds small programs to test Spark specific features.
+To build the jar run: `sbt assembly`
+This will create the following assembly:
+lightbend-spark-kubernetes-tests-assembly-latest.jar
+
+Then after you have created your Spark on K8s docker images you need
+to modify them as follows.
+
+- Create a derived image with the following Dockefile:
+```
+ARG IMG
+FROM $IMG
+
+COPY lightbend-spark-kubernetes-tests-assembly-latest.jar /lightbend-spark-kubernetes-tests-assembly-latest.jar
+```
+Assuming your initial image is: `skonto/spark:itests`
+
+```
+docker build  --build-arg IMG=skonto/spark:itests -t skonto/spark:itests2 .
+docker push skonto/spark:itests2
+```
+
+Then on your host machine make sure you have connected to a remote DC/OS cluster which has (DC/OS KDFS, HDFS and Kuebernetes installed).
+
+Then run:
+```
+export HADOOP_CONFIG_URL=http://api.hdfs.marathon.l4lb.thisdcos.directory/v1/endpoints
+export EXTRA_JARS=/lightbend-spark-kubernetes-tests-assembly-latest.jar
+export TGZ_PATH=<path to spark tzg to use for exampke: /path/to/spark-2.4.0-SNAPSHOT-bin-lightbend.tgz>
+export KAFKA_BROKERS=broker.kafka.l4lb.thisdcos.directory:9092
+
+./dev/dev-run-integration-tests.sh --extra-jars $EXTRA_JARS --deploy-mode cloud --spark-master k8s://http://localhost:9000 --service-account spark-sa --namespace spark --image-tag itests2 --spark-tgz $TGZ_PATH --image-repo skonto --exclude-tags noDcos
+```
+
+The above will run the tests against the remote DC/OS cluster and also will exclude any tests tagged with `noDcos` tag.
+THe extra jar variable refers to the jar that resides in the docker image, and is passed to spark-submit in cluster mode directly with the flag `--jars`.

--- a/resource-managers/kubernetes/lightbend-build/build.sbt
+++ b/resource-managers/kubernetes/lightbend-build/build.sbt
@@ -1,0 +1,47 @@
+name := "lightbend-spark-kubernetes-tests"
+
+organization := "com.lightbend"
+
+version := "latest"
+
+lazy val root = project in file(".")
+
+scalaVersion := "2.11.8"
+
+val sparkVersion = "2.3.0"
+
+libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
+  "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
+  "org.apache.spark" %% "spark-streaming" % sparkVersion % "provided",
+  "org.apache.spark" %% "spark-sql-kafka-0-10" % sparkVersion,
+  "com.github.scopt" %% "scopt" % "3.5.0"
+
+)
+
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-encoding", "UTF-8",
+  "-feature",
+  "-language:existentials",
+  "-language:higherKinds",
+  "-language:implicitConversions",
+  "-language:experimental.macros",
+  "-language:postfixOps",
+  "-unchecked",
+  "-Xlint",
+  "-Yinline-warnings",
+  "-Yno-adapted-args",
+  "-Ywarn-dead-code",
+  "-Ywarn-numeric-widen",
+  "-Ywarn-unused-import",
+  "-Xfuture")
+
+assemblyMergeStrategy in assembly := {
+  case PathList("META-INF", "MANIFEST.MF") => MergeStrategy.discard
+  case PathList("META-INF", xs @ _*) => MergeStrategy.last
+  case PathList(xs @ _*) if xs.last == "UnusedStubClass.class" => MergeStrategy.last
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
+}

--- a/resource-managers/kubernetes/lightbend-build/project/build.properties
+++ b/resource-managers/kubernetes/lightbend-build/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.1.6

--- a/resource-managers/kubernetes/lightbend-build/project/plugins.sbt
+++ b/resource-managers/kubernetes/lightbend-build/project/plugins.sbt
@@ -1,0 +1,2 @@
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")

--- a/resource-managers/kubernetes/lightbend-build/src/main/scala/com/lightbend/fdp/spark/k8s/test/KafkaSimpleProducer.scala
+++ b/resource-managers/kubernetes/lightbend-build/src/main/scala/com/lightbend/fdp/spark/k8s/test/KafkaSimpleProducer.scala
@@ -1,0 +1,55 @@
+package com.lightbend.fdp.spark.k8s.test
+
+import java.util.Properties
+
+import org.apache.kafka.clients.producer.{KafkaProducer, ProducerRecord}
+
+case class KafkaSimpleProducerConfig(
+    topic: String = "",
+    bootstrapServers: String = "",
+    step: Int = 1,
+    maxRecords: Int = 1
+  )
+
+object KafkaSimpleProducer {
+  def main(args: Array[String]): Unit = {
+    val parser = new scopt.OptionParser[KafkaSimpleProducerConfig]("KafkaSimpleProducer") {
+      help("help").text("prints this usage text")
+      opt[String]('o', "topic").required().valueName("<topic>")
+        .action( (x, c) =>
+          c.copy(topic = x) ).text(s"Kafka topic to to get the data from.")
+      opt[String]('o', "bootstrapServers").required().valueName("<servers>")
+        .action( (x, c) =>
+          c.copy(bootstrapServers = x) ).text(s"Kafka servers string.")
+      opt[Int]('o', "step").required().valueName("<step>")
+        .action( (x, c) =>
+          c.copy(step = x) ).text(s"step for records generated.")
+      opt[Int]('o', "maxRecords").required().valueName("<maxRecords>")
+        .action( (x, c) =>
+          c.copy(maxRecords = x) ).text(s"maxRecords to generate.")
+    }
+
+    val conf = parser.parse(args, KafkaSimpleProducerConfig())
+    conf match {
+      case Some(config) =>
+        val  props = new Properties()
+        props.put("bootstrap.servers", config.bootstrapServers)
+        props.put("acks","1")
+        props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+        props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer")
+        val producer = new KafkaProducer[String, String](props)
+        val topic=config.topic
+        val maxRecords = config.maxRecords
+        val step = config.step
+
+        for(i<- 1 + (step-1)*maxRecords to maxRecords*step) {
+          val record = new ProducerRecord(topic, "key:"+i, "value:"+i)
+          println(s"Sending record $i ...")
+          producer.send(record)
+        }
+        println("Success!")
+        producer.close()
+      case None =>
+    }
+  }
+}

--- a/resource-managers/kubernetes/lightbend-build/src/main/scala/com/lightbend/fdp/spark/k8s/test/KafkaToHdfsWithCheckpointing.scala
+++ b/resource-managers/kubernetes/lightbend-build/src/main/scala/com/lightbend/fdp/spark/k8s/test/KafkaToHdfsWithCheckpointing.scala
@@ -1,0 +1,71 @@
+package com.lightbend.fdp.spark.k8s.test
+
+import org.apache.spark.sql.SparkSession
+
+case class KafkaToHdfsWithCheckpointingConfig(
+    checkpointDirectory: String= "",
+    topic: String = "",
+    bootstrapServers: String = ""
+  )
+
+case class Data(key: String, value: String)
+
+/**
+  * Uses structured streaming to copy data of the form (string, string) from
+  * Kafka to HDFS. Checkpointing for the driver and the streams is enabled.
+  */
+object KafkaToHdfsWithCheckpointing {
+  def main(args: Array[String]): Unit = {
+    val appName="KafkaToHdfsWithCheckpointing"
+    val parser = new scopt.OptionParser[KafkaToHdfsWithCheckpointingConfig](appName) {
+      help("help").text("prints this usage text")
+      opt[String]('o', "checkpointDirectory").required().valueName("<dir>")
+        .action( (x, c) =>
+          c.copy(checkpointDirectory = x) ).text(s"Checkpoint directory.")
+      opt[String]('o', "topic").required().valueName("<topic>")
+        .action( (x, c) =>
+          c.copy(topic = x) ).text(s"Kafka topic to to get the data from.")
+      opt[String]('o', "bootstrapServers").required().valueName("<servers>")
+        .action( (x, c) =>
+          c.copy(bootstrapServers = x) ).text(s"Kafka servers string.")
+    }
+
+    val conf = parser.parse(args, KafkaToHdfsWithCheckpointingConfig())
+
+    conf match {
+      case Some(config) =>
+
+        Util.setStreamingLogLevels()
+
+        val spark = SparkSession
+          .builder
+          .appName("Test Kafka to Hdfs with Structured Streaming.")
+          .getOrCreate()
+
+        import spark.implicits._
+
+        val df = spark
+          .readStream
+          .format("kafka")
+          .option("checkpointLocation", config.checkpointDirectory + "_read")
+          .option("kafka.bootstrap.servers", config.bootstrapServers)
+          .option("subscribe", config.topic)
+          .option("startingOffsets", "earliest")
+          .load()
+
+        df.printSchema()
+
+        df.selectExpr("CAST(key AS STRING)", "CAST(value AS STRING)")
+          .as[Data]
+          .createOrReplaceTempView("updates")
+
+        val query = spark.sql("select count(*) from updates")
+          .writeStream
+          .outputMode("complete")
+          .format("console")
+          .start()
+        query.awaitTermination()
+      case None =>
+    }
+  }
+}

--- a/resource-managers/kubernetes/lightbend-build/src/main/scala/com/lightbend/fdp/spark/k8s/test/Util.scala
+++ b/resource-managers/kubernetes/lightbend-build/src/main/scala/com/lightbend/fdp/spark/k8s/test/Util.scala
@@ -1,0 +1,18 @@
+package com.lightbend.fdp.spark.k8s.test
+
+import org.apache.log4j.{Level, Logger}
+
+import org.apache.spark.internal.Logging
+
+object Util extends Logging {
+  def setStreamingLogLevels() {
+    val log4jInitialized = Logger.getRootLogger.getAllAppenders.hasMoreElements
+    if (!log4jInitialized) {
+      // We first log something to initialize Spark's default logging, then we override the
+      // logging level.
+      logInfo("Setting log level to [WARN] for streaming example." +
+        " To override add a custom log4j.properties to the classpath.")
+      Logger.getRootLogger.setLevel(Level.WARN)
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Adds custom tests. Modifies a limited number of files and will try to upstream what is possible to minimize merge conflicts in the future.
- Adds some functionality back from the repo here (https://github.com/databricks/spark-integration-tests).
Cloud support was removed from the upstream spark project.
- This work has revealed the following bugs:
https://issues.apache.org/jira/browse/SPARK-24711
https://issues.apache.org/jira/browse/SPARK-24694
Fixes are upstreamed.
- There is a comprehensive read me file for how to run the tests. Next step is to add them to Jenkins
- The PR is against the k8s-develop branch which is updated according to master. In the future in its jenkins build we will try to merge with the latest changes from upstream. In case of conflicts we will solve them manually. The benefit is that we have tests in one place.
- Tests cover HDFS and Kafka. Tests are tagged so we can pick the ones we want for example based on security (coming soon, PR is already out).
## How was this patch tested?
Manually, check image bellow:

![image](https://user-images.githubusercontent.com/7945591/42138511-55d1c1a0-7d87-11e8-9080-1f839671486b.png)


